### PR TITLE
Fix issue #18, memory leak bug

### DIFF
--- a/src/band.js
+++ b/src/band.js
@@ -397,7 +397,7 @@
         this.destroy = function() {
           this.stop(false);
           totalDuration = 0;
-          instruments = [];
+          instruments.length = 0;
         }
 
         /**


### PR DESCRIPTION
Fix memory leak caused by setting `instruments = []` rather than `instruments.length = 0`. This is a bugfix for issue #18.
