### PR TITLE
Specify `load` return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ instrument pack if one is not specified.</td>
 <tr>
 <td valign="top"><code>load(json)</code></td>
 <td valign="top"><code>json: JSON</code></td>
-<td>Load a song into Band.js using JSON. Format is: (**This will erase your current song and overwrite it with this new one**)<br>
+<td>Load a song into Band.js using JSON. Returns the Player Class. Format is: (**This will erase your current song and overwrite it with this new one**)<br>
 <pre>{
     timeSignature: [4, 4],
     tempo: 100,


### PR DESCRIPTION
Specify the return value for the `load(json)` method of the Conductor class in the README API documentation.

I was having trouble getting `load` to work with the sample provided. When I looked at the source code, I saw that `load` returns `conductor.finish()` and was easily able to get it working.