### PR TITLE
Close old AudioContexts

### DIFF
--- a/src/conductor.js
+++ b/src/conductor.js
@@ -175,6 +175,7 @@ function Conductor(tuning, rhythm) {
      * Remove all instruments and recreate AudioContext
      */
     conductor.destroy = function() {
+        conductor.audioContext.close();
         conductor.audioContext = new AudioContext();
         conductor.instruments.length = 0;
         conductor.masterVolume = conductor.audioContext.createGain();


### PR DESCRIPTION
"The `close()` method of the AudioContext Interface closes the audio context, releasing any system audio resources that it uses [...] it will forcibly release any system audio resources that might prevent additional AudioContexts from being created and used"

from https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/close

The `destroy` method of the Conductor class instantiates new AudioContexts but does not `close` the old ones. Firefox either closes the AudioContexts for you, or otherwise deals with the situation, but Chrome will give an error if enough AudioContexts are instantiated without being closed:

> [band.js:191](https://github.com/meenie/band.js/blob/master/dist/band.js#L191) Uncaught NotSupportedError: Failed to construct 'AudioContext': The number of hardware contexts provided (6) is greater than or equal to the maximum bound (6).

This error is reproducible by calling the `destroy` method enough (~5 times. `destroy` is [called when loading from JSON](https://github.com/meenie/band.js/blob/master/dist/band.js#L90)).

Google Chrome Version 51.0.2704.103